### PR TITLE
Fix builds with nRF SDK by adding an additional version check

### DIFF
--- a/port/platform/zephyr/src/ncs_version.h
+++ b/port/platform/zephyr/src/ncs_version.h
@@ -1,0 +1,11 @@
+#ifndef _NCS_VERSION_H_
+#define _NCS_VERSION_H_
+
+/* This file only exists as a dummy to allow u_port_os.c to compile when not
+ * building against Nordic's nRF SDK. This is needed because nRF SDK version
+ * 2.7.0 is based on a state of Zephyr 3.6.99 that contains the relevant
+ * breaking changes, but isn't caught by the existing kernel version check.
+ */
+
+#endif
+

--- a/port/platform/zephyr/src/u_port_os.c
+++ b/port/platform/zephyr/src/u_port_os.c
@@ -76,6 +76,7 @@
 #include "u_port_os.h"
 
 #include <version.h>
+#include <ncs_version.h>
 
 #if KERNEL_VERSION_NUMBER >= ZEPHYR_VERSION(3,1,0)
 #include <zephyr/kernel.h>
@@ -168,7 +169,13 @@ static uPortOsThreadInstance_t *pGetNewThreadInstance(size_t stackSizeBytes)
             // the need for K_KERNEL_STACK_LEN()
 #if KERNEL_VERSION_NUMBER >= ZEPHYR_VERSION(3,7,0)
             stackAllocSize = K_KERNEL_STACK_LEN(stackSizeBytes);
+#elif defined(NCSVERSION)
+#if NCS_VERSION_NUMBER >= 0x20700 // v2.7.0
+            stackAllocSize = K_KERNEL_STACK_LEN(stackSizeBytes);
 #else
+            stackAllocSize = Z_KERNEL_STACK_LEN(stackSizeBytes);
+#endif // NCS_VERSION_NUMBER
+#else // KERNEL_VERSION_NUMBER
             stackAllocSize = Z_KERNEL_STACK_LEN(stackSizeBytes);
 #endif
             threadPtr->pStack = k_aligned_alloc(Z_KERNEL_STACK_OBJ_ALIGN, stackAllocSize);


### PR DESCRIPTION
Since the nRF SDK is tracking non-standard Zepyhr versions, the otherwise correct kernel version check in `port/platform/zephyr/src/u_port_os.c` fails to catch when building against nRF SDK version 2.7.0 (which pulls in a version of Zephyr marked as kernel version 3.6.99, but containing the relevant changes).

This PR adds an additional check depending on whether an nRF SDK version can be detected, as well as a dummy header for builds without the SDK.